### PR TITLE
chore: Minor change to use https in the github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "http://docs.rs/img_hash"
 
 keywords = ["image", "hash", "perceptual", "difference"]
 
-repository = "http://github.com/abonander/img_hash"
+repository = "https://github.com/abonander/img_hash"
 
 edition = "2015"
 


### PR DESCRIPTION
GitHub redirects to the address with https anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/97